### PR TITLE
Add 'method' as an expected link attribute

### DIFF
--- a/hal.js
+++ b/hal.js
@@ -18,7 +18,7 @@
 
       // If value is a hashmap, just copy properties
       if (!value.href) throw new Error('Required <link> attribute "href"');
-      var expectedAttributes = ['rel', 'href', 'name', 'hreflang', 'title', 'templated','icon','align'];
+      var expectedAttributes = ['rel', 'href', 'name', 'hreflang', 'title', 'templated', 'icon', 'align', 'method'];
       for (var attr in value) {
         if (value.hasOwnProperty(attr)) {
           if (!~expectedAttributes.indexOf(attr)) {


### PR DESCRIPTION
Add 'method' as an expected link attribute.  Appreciate this is non-standard, but works nicely with clients like Halon (https://github.com/LeanKit-Labs/halon#wait-what-are-you-doing-in-addition-to-hal)

There was some debate on the hal spec [here](https://github.com/mikekelly/hal_specification/issues/24) about adding method as an optional attribute, which did determine not to add it to the spec... but if you don't mind adding it as a permitted attribute, it would certainly help our use case where we use multiple link relations for different operations on the same resource to explicitly signal which operation is permitted without requiring a separate OPTIONS request.

